### PR TITLE
Generate Ubuntu, Debian and Fedora Tart VM images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,56 @@
+persistent_worker:
+  labels:
+    name: dev-mini
+  resources:
+    tart-vms: 1
+
+task:
+  matrix:
+    - name: Ubuntu
+      env:
+        VM_NAME: "ubuntu"
+        URL: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img
+        USER_DATA_FIXTURE: "cloud-init/user-data.distro-with-admin-group"
+    - name: Debian
+      env:
+        VM_NAME: "debian"
+        URL: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-generic-arm64.qcow2
+        USER_DATA_FIXTURE: "cloud-init/user-data.distro-without-admin-group"
+    - name: Fedora
+      env:
+        VM_NAME: "fedora"
+        URL: https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2
+        USER_DATA_FIXTURE: "cloud-init/user-data.distro-without-admin-group"
+
+  install_dependencies_script:
+    - brew install wget qemu cdrtools packer
+
+  download_cloud_image_disk_script:
+    - wget -O "$QCOW2_IMAGE" "$URL" || true
+
+  convert_and_resize_cloud_image_disk_script:
+    - qemu-img convert -p -f qcow2 -O raw "$QCOW2_IMAGE" "$RAW_IMAGE"
+    - qemu-img resize "$RAW_IMAGE" 50G
+
+  generate_cloud_init_image_script:
+    - echo "local-hostname: $VM_NAME" > cloud-init/meta-data
+    - cat "$USER_DATA_FIXTURE" > cloud-init/user-data
+    - mkisofs -output cloud-init.iso -volid cidata -joliet -rock cloud-init/
+
+  create_vm_script:
+    - tart delete "$VM_NAME" || true
+    - tart create --linux "$VM_NAME"
+    - mv "$RAW_IMAGE" ~/.tart/vms/"$VM_NAME"/disk.img
+
+  initialize_vm_script:
+    - packer init .
+    - packer build -var vm_name="$VM_NAME" .
+
+  always:
+    cleanup_script:
+      - tart delete "$VM_NAME" || true
+
+  env:
+    QCOW2_IMAGE: image.qcow2
+    RAW_IMAGE: image.raw
+    PACKER_LOG: 1

--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -1,0 +1,30 @@
+packer {
+  required_plugins {
+    tart = {
+      source  = "github.com/cirruslabs/tart"
+      version = ">= 1.6.1"
+    }
+  }
+}
+
+variable "vm_name" {
+  type = string
+}
+
+source "tart-cli" "tart" {
+  vm_name = "${var.vm_name}"
+  run_extra_args = ["--disk", "cloud-init.iso"]
+  headless = false
+  ssh_username = "admin"
+  ssh_password = "admin"
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+
+  provisioner "shell" {
+    inline = [
+      "uname -a"
+    ]
+  }
+}

--- a/cloud-init/user-data.distro-with-admin-group
+++ b/cloud-init/user-data.distro-with-admin-group
@@ -1,0 +1,11 @@
+#cloud-config
+
+users:
+  - name: admin
+    primary_group: admin
+    plain_text_passwd: admin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: False
+    shell: /bin/bash
+
+ssh_pwauth: True

--- a/cloud-init/user-data.distro-without-admin-group
+++ b/cloud-init/user-data.distro-without-admin-group
@@ -1,0 +1,10 @@
+#cloud-config
+
+users:
+  - name: admin
+    plain_text_passwd: admin
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: False
+    shell: /bin/bash
+
+ssh_pwauth: True


### PR DESCRIPTION
The only thing that is missing is the `tart push` part and the `TART_REGISTRY_{USERNAME,PASSWORD}` credentials for this repository that `tart push` could use.

See https://github.com/cirruslabs/tart/issues/624.