### PR TITLE
Configure the networking properly and disable the Cloud Init

### DIFF
--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -24,7 +24,11 @@ build {
 
   provisioner "shell" {
     inline = [
-      "uname -a"
+      # Disable Cloud Init[1] to avoid wasting time
+      # trying to crawl non-existent metadata
+      #
+      # [1]: https://cloudinit.readthedocs.io/en/latest/howto/disable_cloud_init.html#method-1-text-file
+      "sudo touch /etc/cloud/cloud-init.disabled"
     ]
   }
 }

--- a/cloud-init/network-config
+++ b/cloud-init/network-config
@@ -1,0 +1,9 @@
+#cloud-config
+
+network:
+  version: 2
+  ethernets:
+    all:
+      match:
+        name: en*
+      dhcp4: true


### PR DESCRIPTION
This fixes the slow (up to 30 second) loading times of the Linux images due to needless metadata crawling attempts.

To fix this, we disable Cloud Init after the initial configuration (via the attached `cloud-init.iso`) is done.

However, currently we don't configure any networking, which causes the Cloud Init to apply a [fallback network configuration](https://cloudinit.readthedocs.io/en/latest/explanation/boot.html#local). And if we just disable the Cloud Init, no networking will be configured.

So configure the networking properly (I've tested and it seems to work fine on Ubuntu, Debian and Fedora).

Another alternative to disabling the Cloud Init that I've considered, for future reference:

```shell
echo 'datasource_list: [ None ]' | sudo tee /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg
```