### PR TITLE
Resize base images to 20 GB

### DIFF
--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -13,6 +13,7 @@ variable "vm_name" {
 
 source "tart-cli" "tart" {
   vm_name = "${var.vm_name}"
+  disk_size_gb = 20
   run_extra_args = ["--disk", "cloud-init.iso"]
   headless = false
   ssh_username = "admin"


### PR DESCRIPTION
Unfortunately, after attempting to reduce the CPU time spent processing large images in https://github.com/cirruslabs/linux-image-templates/pull/7,  the`ghcr.io/cirruslabs/ubuntu-runner-arm64` image [still grew to 20 GB](https://github.com/cirruslabs/linux-image-templates/blob/80bb9c97810b6b3ede1f51b66563f7aeca34a286/customizations/linux-runner/linux-runner.pkr.hcl#L21).

Let's make all images to be 20 GB in size, because one doesn't just run Linux to look at the console, people install software and so on.

See https://github.com/cirruslabs/tart/pull/712.