### PR TITLE
Set legacy ANDROID_SDK_ROOT

### DIFF
--- a/customizations/linux-runner/playbook.yml
+++ b/customizations/linux-runner/playbook.yml
@@ -568,6 +568,7 @@
         content: |
           export PATH="$PATH:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/emulator"
           export ANDROID_HOME="/opt/android-sdk"
+          export ANDROID_SDK_ROOT="$ANDROID_HOME"
         dest: /etc/profile.d/cirruslabs.sh
         mode: a+x
 


### PR DESCRIPTION
Same as `ANDROID_HOME`. `ANDROID_SDK_ROOT` is a legacy name which is still used by some tools.