### PR TITLE
cloud-init: use lowercase boolean values

### DIFF
--- a/cloud-init/user-data.distro-with-admin-group
+++ b/cloud-init/user-data.distro-with-admin-group
@@ -5,7 +5,7 @@ users:
     primary_group: admin
     plain_text_passwd: admin
     sudo: ALL=(ALL) NOPASSWD:ALL
-    lock_passwd: False
+    lock_passwd: false
     shell: /bin/bash
 
-ssh_pwauth: True
+ssh_pwauth: true

--- a/cloud-init/user-data.distro-without-admin-group
+++ b/cloud-init/user-data.distro-without-admin-group
@@ -4,7 +4,7 @@ users:
   - name: admin
     plain_text_passwd: admin
     sudo: ALL=(ALL) NOPASSWD:ALL
-    lock_passwd: False
+    lock_passwd: false
     shell: /bin/bash
 
-ssh_pwauth: True
+ssh_pwauth: true


### PR DESCRIPTION
cloud-init is at it again: now the `True` doesn't seem to be parsed correctly, and we need to use `true` instead in `ssh_pwauth` to enable the SSH password-based authentication.

I've also changed the `False` in `lock_passwd` to `false`, just in case.

Resolves https://github.com/cirruslabs/linux-image-templates/issues/25.