### PR TITLE
Override Cloud Init's default OpenSSH password authentication setting

### DIFF
--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -33,7 +33,11 @@ build {
       #
       # [1]: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
       # [2]: https://github.com/cirruslabs/linux-image-templates/pull/8
-      "echo 'datasource_list: [ None ]' | sudo tee /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
+      "echo 'datasource_list: [ None ]' >> /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg",
+      # Cloud Init creates a /etc/ssh/sshd_config.d/50-cloud-init.conf file on Fedora
+      # with "PasswordAuthentication no" contents despite us setting the
+      # "ssh_pwauth: true" in "user-data" file, so override this behavior.
+      "echo 'ssh_pwauth: true' >> /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
     ]
   }
 }

--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -33,11 +33,11 @@ build {
       #
       # [1]: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
       # [2]: https://github.com/cirruslabs/linux-image-templates/pull/8
-      "echo 'datasource_list: [ None ]' >> /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg",
+      "echo 'datasource_list: [ None ]' | sudo tee -a /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg",
       # Cloud Init creates a /etc/ssh/sshd_config.d/50-cloud-init.conf file on Fedora
       # with "PasswordAuthentication no" contents despite us setting the
       # "ssh_pwauth: true" in "user-data" file, so override this behavior.
-      "echo 'ssh_pwauth: true' >> /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
+      "echo 'ssh_pwauth: true' | sudo tee -a /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
     ]
   }
 }


### PR DESCRIPTION
It seems that I was checking the fix for the https://github.com/cirruslabs/linux-image-templates/issues/25 incorrectly and https://github.com/cirruslabs/linux-image-templates/pull/26 doesn't really work: `/etc/ssh/sshd_config.d/50-cloud-init.conf` with `PasswordAuthentication no` still does get created.

Resolves https://github.com/cirruslabs/linux-image-templates/issues/25.