### PR TITLE
Pre-create .NET folder used by `actions/setup-dotnet`

### DIFF
--- a/customizations/linux-runner/playbook-runner.yml
+++ b/customizations/linux-runner/playbook-runner.yml
@@ -15,6 +15,13 @@
         group: admin
         state: directory
 
+    - name: create .NET directory
+      file:
+        path: /usr/share/dotnet
+        owner: admin
+        group: admin
+        state: directory
+
     # Language and Runtime[1]
     #
     # [1]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime


### PR DESCRIPTION
As described in https://github.com/actions/setup-dotnet/tree/5d1464d5da459f3d7085106d52e499f4dc5d0f59?tab=readme-ov-file#environment-variables