### PR TITLE
Persistent DHCP identifier fix

### DIFF
--- a/99_cirruslabs.cfg
+++ b/99_cirruslabs.cfg
@@ -1,0 +1,29 @@
+# We can't disable the Cloud Init because otherwise we loose the growpart functionality[1],
+# so disable all data sources instead.
+#
+# Also see [2] for more details.
+#
+# [1]: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
+# [2]: https://github.com/cirruslabs/linux-image-templates/pull/8
+datasource_list: [ None ]
+
+# Cloud Init creates a /etc/ssh/sshd_config.d/50-cloud-init.conf file on Fedora
+# with "PasswordAuthentication no" contents despite us setting the
+# "ssh_pwauth: true" in "user-data" file, so override this behavior.
+ssh_pwauth: true
+
+# Since we disable all data sources above to speed-up the booting process,
+# we need to somehow provide our DHCP identifier fix from "network-config".
+network:
+  version: 2
+  ethernets:
+    all:
+      match:
+        name: en*
+      dhcp4: true
+
+      # Work around macOS DHCP server treating "hw_address" and "identifier" fields
+      # in /var/db/dhcpd_leases the same way and putting client identifier (which is
+      # a DUID/IAID) into the "hw_address" field, making it impossible to locate the
+      # corresponding entry given a MAC-address in "tart ip".
+      dhcp-identifier: mac

--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -24,20 +24,14 @@ source "tart-cli" "tart" {
 build {
   sources = ["source.tart-cli.tart"]
 
+  provisioner "file" {
+    source = "99_cirruslabs.cfg"
+    destination = "/tmp/99_cirruslabs.cfg"
+  }
+
   provisioner "shell" {
     inline = [
-      # We can't disable the Cloud Init because otherwise we loose the growpart functionality[1],
-      # so disable all data sources instead.
-      #
-      # Also see [2] for more details.
-      #
-      # [1]: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#growpart
-      # [2]: https://github.com/cirruslabs/linux-image-templates/pull/8
-      "echo 'datasource_list: [ None ]' | sudo tee -a /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg",
-      # Cloud Init creates a /etc/ssh/sshd_config.d/50-cloud-init.conf file on Fedora
-      # with "PasswordAuthentication no" contents despite us setting the
-      # "ssh_pwauth: true" in "user-data" file, so override this behavior.
-      "echo 'ssh_pwauth: true' | sudo tee -a /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
+      "cat /tmp/99_cirruslabs.cfg | sudo tee /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
     ]
   }
 }


### PR DESCRIPTION
Since we disable all data sources above to speed-up the booting process, we need to somehow provide our DHCP identifier fix from "network-config".

Otherwise the fix will only be visible on the initial VM boot, which I was testing https://github.com/cirruslabs/linux-image-templates/pull/38 on.