### PR TITLE
Install Homebrew on amd64

### DIFF
--- a/customizations/linux-runner-gpu/linux-runner-gpu.pkr.hcl
+++ b/customizations/linux-runner-gpu/linux-runner-gpu.pkr.hcl
@@ -18,7 +18,7 @@ variable "vm_name" {
 source "tart-cli" "tart" {
   vm_base_name = "ghcr.io/cirruslabs/ubuntu-runner-amd64:latest"
   vm_name = "${var.vm_name}"
-  disk_size_gb = 25
+  disk_size_gb = 30
   headless = false
   disable_vnc = true
   ssh_username = "admin"

--- a/customizations/linux-runner/playbook-runner.yml
+++ b/customizations/linux-runner/playbook-runner.yml
@@ -159,9 +159,24 @@
         name: helm
         install_recommends: false
 
-    # Skip installing Homebrew as it's not supported on arm64 Linux yet[1]
+    # Only install Homebrew on amd64 as it's not supported on arm64 Linux yet[1]
     #
     # [1]: https://docs.brew.sh/Homebrew-on-Linux#arm-unsupported
+    - name: download Homebrew installation script
+      uri:
+        url: https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh
+        return_content: true
+      register: homebrew_installation_script
+      when: ansible_architecture == "x86_64"
+
+    - name: run Homebrew installation script
+      shell:
+        cmd: bash -s
+        stdin: "{{ homebrew_installation_script.content }}"
+      environment:
+        NONINTERACTIVE: 1
+      become: false
+      when: ansible_architecture == "x86_64"
 
     # Skip installing Miniconda as it has no .deb/Snap package(s)[1]
     #


### PR DESCRIPTION
We're not doing the installation on `arm64` because the following error is thrown:

```
$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
==> Checking for `sudo` access (which may request your password)...
[sudo] password for admin: 
Homebrew on Linux is not supported on ARM processors.
  https://docs.brew.sh/Homebrew-on-Linux#arm-unsupported
```

Also, the Homebrew still needs to be added to `PATH` due to https://github.com/actions/runner-images/issues/6283:

```shell
/home/linuxbrew/.linuxbrew/bin/brew shellenv >> $GITHUB_PATH
```

Resolves https://github.com/cirruslabs/linux-image-templates/issues/41.