### PR TITLE
Revert the use of chrony instead of systemd-timesyncd

### DIFF
--- a/customizations/linux-runner/playbook-extras.yml
+++ b/customizations/linux-runner/playbook-extras.yml
@@ -43,18 +43,3 @@
       systemd_service:
         name: apport
         enabled: false
-
-- name: apply boot time optimizations
-  hosts: default
-  become: true
-
-  tasks:
-    - name: uninstall systemd-timesyncd
-      apt:
-        name: systemd-timesyncd
-        state: absent
-
-    - name: install chrony
-      apt:
-        name: chrony
-        state: present


### PR DESCRIPTION
Doesn't help much, in ~30% of cases the time is still out-of-sync.