### PR TITLE
Install Guest agent for Tart VMs on Debian, Ubuntu, Fedora and Rocky

### DIFF
--- a/cloud-init.pkr.hcl
+++ b/cloud-init.pkr.hcl
@@ -34,4 +34,11 @@ build {
       "cat /tmp/99_cirruslabs.cfg | sudo tee /etc/cloud/cloud.cfg.d/99_cirruslabs.cfg"
     ]
   }
+
+  provisioner "ansible" {
+    playbook_file = "./playbook.yml"
+
+    # scp command is only available after we install the openssh-client
+    use_sftp = true
+  }
 }

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,35 @@
+- hosts: default
+  become: true
+
+  tasks:
+    # Guest agent for Tart VMs installation: Debian-based
+    - name: install apt-transport-https and ca-certificates packages
+      apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+        update_cache: yes
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'
+    - name: add Cirrus Labs repository
+      apt_repository:
+        repo: "deb [trusted=yes] https://apt.fury.io/cirruslabs/ /"
+        filename: cirruslabs
+      when: ansible_os_family == 'Debian'
+    - name: install Guest agent for Tart VMs
+      apt:
+        name: tart-guest-agent
+      when: ansible_os_family == 'Debian'
+
+    # Guest agent for Tart VMs installation: RedHat-based
+    - name: add Cirrus Labs repository
+      yum_repository:
+        name: cirruslabs
+        description: "Cirrus Labs repository"
+        baseurl: "https://yum.fury.io/cirruslabs/"
+        gpgcheck: no
+      when: ansible_os_family == 'RedHat'
+    - name: install Guest agent for Tart VMs
+      dnf:
+        name: tart-guest-agent
+      when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
And thus on the runner images too.

The systemd service installation/de-installation will be a part of `.deb`/`.rpm` package scripts in https://github.com/cirruslabs/tart-guest-agent/pull/21.