### PR TITLE
Build Ubuntu images for amd64

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,17 +33,21 @@ task:
     - "Install dependencies ($WORKER_NAME)"
 
   matrix:
-    - name: Ubuntu $VM_RELEASE
+    - name: Ubuntu ($VM_RELEASE $VM_ARCH)
       env:
         VM_NAME: "ubuntu"
         matrix:
           - VM_RELEASE: "24.04"
-            URL: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img
+            URL: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-$VM_ARCH.img"
             LATEST: latest
           - VM_RELEASE: "22.04"
-            URL: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img
-        WORKER_NAME: $WORKER_NAME_ARM64
-        VM_ARCH: "arm64"
+            URL: "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-$VM_ARCH.img"
+        matrix:
+          - VM_ARCH: "arm64"
+            WORKER_NAME: $WORKER_NAME_ARM64
+          - VM_ARCH: "amd64"
+            WORKER_NAME: $WORKER_NAME_AMD64
+            CUSTOMIZATION_IMAGE: "ubuntu-amd64"
         USER_DATA_FIXTURE: "cloud-init/user-data.distro-with-admin-group"
     - name: Debian
       env:


### PR DESCRIPTION
## Summary

- build Ubuntu 22.04 and 24.04 base images for amd64
- run the amd64 variants on the `dev-mini-amd64` persistent worker
- keep the existing arm64 image names and publish amd64 releases as `ubuntu-amd64`

## Why

The base Ubuntu image matrix only covered arm64. The new amd64 persistent worker now allows us to build and validate native amd64 Tart images in the same pipeline.

## Validation

- `.cirrus.yml` parses as YAML
- `git diff --check` passes
- both Ubuntu amd64 cloud-image URLs return HTTP 200
- Cirrus CI pending